### PR TITLE
Fix GoLint, Adds method for PrefixQueueInDev

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+//Publisher allows you to publish events to RabbitMQ
 type Publisher struct {
 	_connection       *amqp.Connection
 	_channel          *amqp.Channel
@@ -158,6 +159,7 @@ func (p *Publisher) PublishBytes(message []byte, subscriber *Subscriber) error {
 		})
 }
 
+//Close will close the connection and channel for the Publisher
 func (p *Publisher) Close() {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/rabbit.go
+++ b/rabbit.go
@@ -7,7 +7,7 @@ import (
 	"github.com/streadway/amqp"
 )
 
-var _connection *amqp.Connection = nil
+var _connection *amqp.Connection
 
 func failOnError(err error, msg string) {
 	if err != nil {

--- a/slice.go
+++ b/slice.go
@@ -1,0 +1,10 @@
+package rabbit
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/subscriber.go
+++ b/subscriber.go
@@ -2,7 +2,10 @@ package rabbit
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"os"
+	"os/user"
 	"sync"
 )
 
@@ -11,7 +14,7 @@ var (
 	Subscribers map[string]Subscriber
 	// Handlers is a map of all of the registered Subscriber Handlers
 	Handlers           map[string]func(b []byte) bool
-	subscribersStarted bool = false
+	subscribersStarted = false
 	lock               sync.RWMutex
 )
 
@@ -93,6 +96,7 @@ func Register(s Subscriber, handler func(b []byte) bool) {
 	Handlers[s.RoutingKey] = handler
 }
 
+// CloseSubscribers removes all subscribers, handlers, and closes the amqp connection
 func CloseSubscribers() {
 	lock.Lock()
 	defer lock.Unlock()
@@ -106,6 +110,7 @@ func CloseSubscribers() {
 	}
 }
 
+//DeleteQueue does what it says, deletes a queue in rabbit
 func DeleteQueue(s Subscriber) error {
 	conn := connection()
 	if conn == nil {
@@ -119,4 +124,44 @@ func DeleteQueue(s Subscriber) error {
 		return errors.New("Can't delete a queue: can't create a channel")
 	}
 	return deleteQueue(channel, &s)
+}
+
+// PrefixQueueInDev will prefix the queue name with the name of the APP_ENV variable.
+// This is used for running a worker in your local environment but connecting to a stage
+// or prodution rabbit server.
+func (s *Subscriber) PrefixQueueInDev() {
+	env := appEnv()
+	nonDevEnvironments := []string{"production", "prod", "staging", "stage"}
+
+	if stringInSlice(env, nonDevEnvironments) {
+		return
+	}
+
+	username := currentUsersName()
+
+	if env == "test" {
+		username = "test_" + username
+	}
+
+	s.Queue = fmt.Sprintf("%s_%s", username, s.Queue)
+}
+
+func appEnv() string {
+	env := os.Getenv("APP_ENV")
+
+	// Check PLATFORM_ENV for backwards compatibility
+	if len(env) == 0 {
+		env = os.Getenv("PLATFORM_ENV")
+	}
+	return env
+}
+
+func currentUsersName() string {
+	username := "unknown"
+
+	if userData, err := user.Current(); err == nil {
+		username = userData.Username
+	}
+
+	return username
 }

--- a/subsriber_test.go
+++ b/subsriber_test.go
@@ -1,0 +1,27 @@
+package rabbit_test
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/brettallred/rabbit-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixQueueInDev(t *testing.T) {
+	var subscriber = rabbit.Subscriber{
+		Concurrency: 5,
+		Durable:     true,
+		Exchange:    "events",
+		Queue:       "test.sample.event.created",
+		RoutingKey:  "sample.event.created",
+	}
+
+	os.Setenv("APP_ENV", "development")
+	subscriber.PrefixQueueInDev()
+	userData, _ := user.Current()
+
+	assert.Equal(t, subscriber.Queue, fmt.Sprintf("%s_test.sample.event.created", userData.Username))
+}


### PR DESCRIPTION
Throughout our codebases we are seeing a common pattern


```
	nuvisSubscriber := rabbit.Subscriber{
		Queue:         prefix + "sentiment_learner.nuvis.sentiment_phrase_score.updated",
	}
```

This pattern requires us to have code in each app to determine a prefix.  This moves that logic to rabbit-go allowing you to simply add

```
nuvisSubscriber.PrefixQueueInDev()
```
